### PR TITLE
Deps: update Hugo to 0.148.2 and Hextra to 0.10.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/hugo:1": {
       "extended": true,
-      "version": "0.132.2"
+      "version": "0.148.2"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.132.2
+      HUGO_VERSION: 0.148.2
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.21
 
 require (
 	github.com/FreeCAD/lens-docs v0.0.0-20250814003308-fe163f978126 // indirect
-	github.com/imfing/hextra v0.9.4 // indirect
+	github.com/imfing/hextra v0.10.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/FreeCAD/lens-docs v0.0.0-20250814003308-fe163f978126 h1:ChCUCPn1GKe/v30M3ZP9PApLZJ8LeFKyGzHVh5qlcoM=
 github.com/FreeCAD/lens-docs v0.0.0-20250814003308-fe163f978126/go.mod h1:ze5556OWqU3rzHMiJ9FsV+qxhFEYhWeX1NsuWLV995M=
-github.com/imfing/hextra v0.9.4 h1:k1KEC2mtYbMVBMOYUYK5Yy8pNPpIH3u6pBTRyBSN6No=
-github.com/imfing/hextra v0.9.4/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.10.1 h1:W2vI4Hot7z9lRcTmRFRQ1rzpnybp2tTuY6yHsRDUXq4=
+github.com/imfing/hextra v0.10.1/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "public"
 command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 
 [build.environment]
-HUGO_VERSION = "0.138.0"
+HUGO_VERSION = "0.148.2"


### PR DESCRIPTION
[Hugo 0.146 (released April 2025)](https://github.com/gohugoio/hugo/releases/tag/v0.146.0) introduced some template changes and a few deprecations. It is recommended to adopt the new structure going forward. Using a consistent version is also recommended.

Hextra, the theme used here, has been [recently updated](https://github.com/imfing/hextra/releases) for these changes.

To update all modules locally, do: `hugo mod get -u`

Tested locally with success.